### PR TITLE
mouse can use clk_ena to reduce clock

### DIFF
--- a/ULX3S/common/hdl/oled/oled_hex_decoder.vhd
+++ b/ULX3S/common/hdl/oled/oled_hex_decoder.vhd
@@ -25,6 +25,7 @@ generic
 port
 (
   clk: in std_logic; -- 1-25 MHz clock typical
+  clk_ena: in std_logic := '1'; -- to reduce clock
   en: in std_logic := '1'; -- enable/hold input for button
   data: in std_logic_vector(C_data_len-1 downto 0);
   spi_resn, spi_clk, spi_csn, spi_dc, spi_mosi: out std_logic := '1'
@@ -100,6 +101,7 @@ begin
   process(clk)
   begin
     if rising_edge(clk) then
+    if clk_ena = '1' then
       if en = '1' then
         if R_holding(R_holding'high) = '0' then
           R_holding <= R_holding + 1;
@@ -113,7 +115,8 @@ begin
       else
         R_go <= '0';
       end if;
-    end if;
+    end if; -- clk_ena
+    end if; -- rising_edge
   end process;
   end generate;
 
@@ -128,6 +131,7 @@ begin
   process(clk)
   begin
     if rising_edge(clk) then
+    if clk_ena = '1' then
       -- if R_go = '1' then
       if R_reset_cnt(R_reset_cnt'high downto R_reset_cnt'high-1) /= "10" then
         R_reset_cnt <= R_reset_cnt+1;
@@ -181,7 +185,8 @@ begin
          R_init_cnt(R_init_cnt'high downto 4) <= conv_std_logic_vector(C_oled_init_seq'high-(C_last_init_send_as_data-1), R_init_cnt'length-4);
       end if;
       -- end if; -- R_go slowdown
-    end if; -- rising edge
+    end if; -- clk_ena
+    end if; -- rising_edge
   end process;
   spi_resn <= not R_reset_cnt(R_reset_cnt'high-1);
   spi_csn <= R_reset_cnt(R_reset_cnt'high-1); -- CS = inverted reset

--- a/library/ps2mouse/mousem.vhd
+++ b/library/ps2mouse/mousem.vhd
@@ -39,6 +39,7 @@ entity mousem is
   port
   (
     clk, ps2m_reset: in std_logic;
+    clk_ena: in std_logic := '1';
     ps2m_clk, ps2m_dat: inout std_logic;
     update: out std_logic;
     x, dx: out std_logic_vector(c_x_bits-1 downto 0);
@@ -148,6 +149,7 @@ begin
   process(clk)
   begin
     if rising_edge(clk) then
+    if clk_ena = '1' then
       filter <= filter(filter'high-1 downto 0) & ps2m_clk;
       count <= count_next;
       req <= (not ps2m_reset) and (not run) and (req xor endcount);
@@ -162,7 +164,10 @@ begin
       r_dy <= s_dy;
       r_dz <= s_dz;
       update <= done;
-    end if;
+      else -- clk_ena = '0'
+      update <= '0';
+    end if; -- clk_ena
+    end if; -- rising_edge
   end process;  
   x <= r_x;
   y <= r_y;

--- a/library/scope/scopeio_ps2mouse2daisy.vhd
+++ b/library/scope/scopeio_ps2mouse2daisy.vhd
@@ -18,6 +18,7 @@ generic
 port
 (
   clk           : in  std_logic;
+  clk_ena       : in  std_logic := '1'; -- to reduce clk to 20-30 MHz
   -- mouse needs reset after replugging (no hotplug detectin yet)
   ps2m_reset    : in  std_logic := '0'; -- PS/2 mouse core reset
   -- PS/2 interface
@@ -58,6 +59,7 @@ begin
   port map
   (
     clk         => clk, -- by default made for 25 MHz
+    clk_ena     => clk_ena, -- used to reduce clk to 20-30 MHz
     ps2m_reset  => ps2m_reset, -- after replugging mouse, it needs reset
     ps2m_clk    => ps2m_clk,
     ps2m_dat    => ps2m_dat,


### PR DESCRIPTION
So you can avoid LUT generated clock, feed mouse and gui with
40 MHz and LUT-generate 20MHz for clk_ena. This will effectively
run mouse at 20 MHz which is ok.

