### PR TITLE
Fixing discontinuity around triggering point T=0

### DIFF
--- a/ULX3S/scopeio/scopeio.vhd
+++ b/ULX3S/scopeio/scopeio.vhd
@@ -20,9 +20,9 @@ architecture beh of ulx3s is
 	-- 2: 1920x1080 @ 30Hz  75MHz
 	-- 3: 1280x768  @ 60Hz  75MHz
 	-- 4: 1280x1024 @ 60Hz 108MHz NOTE: HARD OVERCLOCK
-	-- 5:  800x600  @ 60Hz  40MHz 16-pix grid 2 segments
+	-- 5:  800x600  @ 60Hz  40MHz  8-pix grid 1 segment
 	-- 6:  800x600  @ 60Hz  40MHz 16-pix grid 4 segments FULL SCREEN
-	-- 7:  800x600  @ 60Hz  40MHz 16-pix grid 1 segments 96x64 OLED
+	-- 7:  800x600  @ 60Hz  40MHz  8-pix grid 1 segment 96x64 OLED
         constant vlayout_id: integer := 6;
         constant C_adc: boolean := true; -- true: normal ADC use, false: soft replacement
         constant C_adc_analog_view: boolean := true; -- true: normal use, false: SPI digital debug
@@ -262,7 +262,13 @@ begin
 	  process(clk_adc)
 	  begin
 	    if rising_edge(clk_adc) then
-	      R_test_counter <= R_test_counter + 1;
+	      -- reset counter a bit earlier so the period of
+	      -- test signal will not match with buffering period
+	      if R_test_counter(R_test_counter'high downto 4) = x"FFF" then
+	        R_test_counter <= (others => '0');
+	      else
+	        R_test_counter <= R_test_counter + 1;
+	      end if;
 	    end if;
 	  end process;
 	  S_test_p <= R_test_counter(R_test_counter'high);

--- a/library/scope/scopeio_trigger.vhd
+++ b/library/scope/scopeio_trigger.vhd
@@ -35,7 +35,7 @@ begin
 		if rising_edge(input_clk) then
 			trigger_shot <= (lt and ge and not edge) or (not lt and not ge and edge);
 			lt     := not ge;
-			ge     := setif(signed(sample(0 to trigger_level'length-1)) >= signed(trigger_level));
+			ge     := setif(signed(sample(sample'length - trigger_level'length to sample'high)) >= signed(trigger_level));
 			edge   := not trigger_edge;
 			sample <= word2byte(input_data, trigger_chanid, sample'length);
 		end if;

--- a/library/scope/scopeiopkg.vhd
+++ b/library/scope/scopeiopkg.vhd
@@ -66,7 +66,7 @@ package scopeiopkg is
 	constant vesa1280x1024: natural := 3;
 	constant sd600x16 : natural := 4;
 	constant sd600x16fs : natural := 5;
-	constant sd600x16oled : natural := 6;
+	constant oled96x64  : natural := 6;
 
 	type displaylayout_vector is array (natural range <>) of display_layout;
 
@@ -104,25 +104,25 @@ package scopeiopkg is
 			num_of_segments =>    4,
 			division_size   =>   16,
 			grid_width      =>   30,
-			grid_height     =>    8,
+			grid_height     =>    9,
 			axis_fontsize   =>    8,
 			hzaxis_height   =>    8,
 			vtaxis_width    =>  6*8,
 			textbox_width   => 33*8,
-			main_margin     => (top => 5, left => 1, others => 0),
-			main_gap        => (vertical => 8, others => 0),
-			sgmnt_margin    => (top => 2, bottom => 2, others => 1),
-			sgmnt_gap       => (horizontal => 1, others => 0)),
-		sd600x16oled => (
-			display_width   =>  800,
+			main_margin     => (others => 0),
+			main_gap        => (others => 0),
+			sgmnt_margin    => (others => 0),
+			sgmnt_gap       => (others => 0)),
+		oled96x64 => (
+			display_width   =>   96,
 			num_of_segments =>    1,
-			division_size   =>   16,
-			grid_width      =>    5,
-			grid_height     =>    4,
-			axis_fontsize   =>    8,
-			hzaxis_height   =>    8,
-			vtaxis_width    =>  1*8,
-			textbox_width   =>    1,
+			division_size   =>    8,
+			grid_width      =>    9,
+			grid_height     =>    7,
+			axis_fontsize   =>    4,
+			hzaxis_height   =>    4,
+			vtaxis_width    =>  6*4,
+			textbox_width   =>    1, -- no textbox
 			main_margin     => (others => 0),
 			main_gap        => (others => 0),
 			sgmnt_margin    => (others => 0),
@@ -185,7 +185,7 @@ package scopeiopkg is
 		4 => (mode_id => pclk108_00m1280x1024Cat60, layout_id => vesa1280x1024),
 		5 => (mode_id => pclk38_25m800x600Cat60,    layout_id => sd600x16),
 		6 => (mode_id => pclk38_25m800x600Cat60,    layout_id => sd600x16fs),
-		7 => (mode_id => pclk38_25m800x600Cat60,    layout_id => sd600x16oled));
+		7 => (mode_id => pclk38_25m800x600Cat60,    layout_id => oled96x64));
 
 	constant vtaxis_boxid : natural := 0;
 	constant grid_boxid   : natural := 1;


### PR DESCRIPTION
I tried my best to fix the discontinuity with triggering.
Triggering is made independent from video frame.
Time instance of updating capture address,
which makes discontinuity, is moved away
from triggering point by half of buffer size so

It works well for horizontal zoom out 0-4.

When zooming out for 5 steps or more, some glitches can be
seen around triggering point. I don't know what to do about
that though.
