### PR TITLE
scopeio: shift capture addr 1 pixel to the right

### DIFF
--- a/library/scope/scopeio.vhd
+++ b/library/scope/scopeio.vhd
@@ -630,7 +630,7 @@ begin
 		process(input_clk)
 		begin
 			if rising_edge(input_clk) then
-				scrolled_capture_addr <= std_logic_vector(signed(hz_offset(capture_addr'reverse_range)) + signed(capture_addr));
+				scrolled_capture_addr <= std_logic_vector(signed(hz_offset(capture_addr'reverse_range)) + signed(capture_addr) - to_signed(1,capture_addr'length));
 			end if;
 		end process;
 	end block;


### PR DESCRIPTION
rising edge of triggered squarewave now aligns with the grid
for my 1-shot trigger. I don't know however is that correct way
of alignment or should some latency be used instead.
