### PR TITLE
capture1shot: allow user to scroll frozen display using "input_delay"

### DIFF
--- a/ULX3S/diamond/files.mk
+++ b/ULX3S/diamond/files.mk
@@ -35,8 +35,11 @@ VHDL_LIB_FILES = \
   ../../library/common/btod.vhd \
   ../../library/common/btof.vhd \
   ../../library/common/pll2ser.vhd \
-  ../../library/scope/scopeio.vhd \
+  ../../library/scope/scopeio_xxx.vhd \
   ../../library/scope/scopeiopkg.vhd \
+  ../../library/scope/scopeio_capture1shot.vhd \
+  ../../library/scope/scopeio_resize.vhd \
+  ../../library/scope/scopeio_video.vhd \
   ../../library/scope/scopeio_pointer.vhd \
   ../../library/scope/scopeio_ps2mouse2daisy.vhd \
   ../../library/ps2mouse/mousem.vhd \
@@ -77,6 +80,10 @@ VHDL_LIB_FILES = \
   ../../library/video/cga_rom.vhd \
   ../../library/video/vga2dvid.vhd \
   ../../library/video/tmds_encoder.vhd \
+
+# for new code, replace scopeio.vhd -> scopeio_xxx.vhd
+#  ../../library/scope/scopeio.vhd \
+#  ../../library/scope/scopeio_xxx.vhd \
 
 VERILOG_FILES = \
   $(VERILOG_CLOCK_FILE)

--- a/ULX3S/diamond/ulx3s_12f_scope.ldf
+++ b/ULX3S/diamond/ulx3s_12f_scope.ldf
@@ -84,10 +84,19 @@
     <Source name="../../library/common/pll2ser.vhd" type="VHDL" type_short="VHDL">
       <Options lib="hdl4fpga"/>
     </Source>
-    <Source name="../../library/scope/scopeio.vhd" type="VHDL" type_short="VHDL">
+    <Source name="../../library/scope/scopeio_xxx.vhd" type="VHDL" type_short="VHDL">
       <Options lib="hdl4fpga"/>
     </Source>
     <Source name="../../library/scope/scopeiopkg.vhd" type="VHDL" type_short="VHDL">
+      <Options lib="hdl4fpga"/>
+    </Source>
+    <Source name="../../library/scope/scopeio_capture.vhd" type="VHDL" type_short="VHDL">
+      <Options lib="hdl4fpga"/>
+    </Source>
+    <Source name="../../library/scope/scopeio_resize.vhd" type="VHDL" type_short="VHDL">
+      <Options lib="hdl4fpga"/>
+    </Source>
+    <Source name="../../library/scope/scopeio_video.vhd" type="VHDL" type_short="VHDL">
       <Options lib="hdl4fpga"/>
     </Source>
     <Source name="../../library/scope/scopeio_pointer.vhd" type="VHDL" type_short="VHDL">

--- a/ULX3S/scopeio/scopeio.vhd
+++ b/ULX3S/scopeio/scopeio.vhd
@@ -32,7 +32,7 @@ architecture beh of ulx3s is
 	constant C_adc_timing_exact: integer range 0 to 1 := 1; -- 0 for adc_slowdown = true, 1 for adc_slowdown = false
 	constant C_adc_bits: integer := 12; -- don't touch
 	constant C_adc_channels: integer := 4; -- don't touch
-	constant inputs: natural := 4; -- number of input channels (traces)
+	constant inputs: natural := 1; -- number of input channels (traces)
         constant C_buttons_test: boolean := true; -- false: normal use, true: pressing buttons will test ADC channels
         constant C_oled_hex: boolean := false; -- true: use OLED HEX, false: no oled - can save some LUTs
         constant C_oled_vga: boolean := false; -- false:DVI video, true:OLED video, enable either HEX or VGA, not both OLEDs
@@ -91,8 +91,8 @@ architecture beh of ulx3s is
 
 	-- assign default colors to the traces
 	constant C_tracesfg: std_logic_vector(0 to inputs*vga_rgb'length-1) :=
-        --b"111100";
-          b"111100_001111_001100_110111";
+          b"111100";
+        --b"111100_001111_001100_110111";
         --b"111100_001111_001100_110111_110100";
         --b"111100_001111_001100_110111_110100_000111_011011_111000 111010 001011";
         --  RRGGBB RRGGBB RRGGBB RRGGBB RRGGBB RRGGBB RRGGBB RRGGBB RRGGBB RRGGBB
@@ -493,8 +493,8 @@ begin
 	scopeio_e : entity hdl4fpga.scopeio
 	generic map (
 	        inputs           => inputs, -- number of input channels
-	        axis_unit        => std_logic_vector(to_unsigned(1,5)), -- 1.0 each 128 samples
-	        C_experimental_trigger => true,
+	        --axis_unit        => std_logic_vector(to_unsigned(1,5)), -- 1.0 each 128 samples
+	        --C_experimental_trigger => true,
 		vlayout_id       => vlayout_id,
                 default_tracesfg => C_tracesfg,
                 default_gridfg   => b"110000",

--- a/library/scope/scopeio_xxx.vhd
+++ b/library/scope/scopeio_xxx.vhd
@@ -270,7 +270,7 @@ begin
 		output_dv    => downsample_dv ,
 		output_data  => downsample_data);
 
-	scopeio_capture_e : entity hdl4fpga.scopeio_capture
+	scopeio_capture_e : entity hdl4fpga.scopeio_capture1shot
 	port map (
 		input_clk     => input_clk,
 		capture_req   => capture_req,
@@ -278,6 +278,10 @@ begin
 		input_ena     => downsample_dv,
 		input_data    => downsample_data,
 		input_delay   => hz_offset,
+
+		video_vton    => video_vton,
+		trigger_freeze=> trigger_freeze,
+		trigger_shot  => trigger_shot,
 
 		captured_clk  => video_clk,
 		captured_addr => capture_addr,

--- a/library/scope/scopeiopkg.vhd
+++ b/library/scope/scopeiopkg.vhd
@@ -126,7 +126,7 @@ package scopeiopkg is
 		oled96x64 => (
 			display_width    =>   96,
 			display_height   =>   64,
-			num_of_segments  =>    2,
+			num_of_segments  =>    1,
 			division_size    =>    8,
 			grid_width       => 11*8+1,
 			grid_height      =>  7*8+1,


### PR DESCRIPTION
cleanup and renaming signals to more comprehensive names