### PR TITLE
fix for compilation with diamond 3.7

### DIFF
--- a/library/scope/scopeio.vhd
+++ b/library/scope/scopeio.vhd
@@ -218,10 +218,11 @@ begin
 				return retval;
 			end;
 
+			constant vt_step : real := vt_steps(i);
 			constant gains  : natural_vector(vt_gains'range) := init_gains (
 				gains => vt_gains,
 				unit  => vt_unit,
-				step  => vt_steps(i));
+				step  => vt_step);
 
 			subtype sample_range is natural range i*sample_size to (i+1)*sample_size-1;
 


### PR DESCRIPTION
Diamond 3.7 was failing to compile
constant k      : real := (32.0*step)/unit;
Diamond 3.11 compiled it normally

I traced down the problem and found workaround
with intermediate constant

constant vt_step : real := vt_steps(i);

